### PR TITLE
Improve scheduler timing

### DIFF
--- a/atproto_scheduler/settings.py
+++ b/atproto_scheduler/settings.py
@@ -116,5 +116,5 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # For the post scheduler
-SCHEDULER_INTERVAL = timedelta(seconds=10)
+SCHEDULER_INTERVAL = timedelta(seconds=5)
 TIME_ZONE = "America/New_York"

--- a/schedule_client/schedule_jobs.py
+++ b/schedule_client/schedule_jobs.py
@@ -1,4 +1,3 @@
-from posts.models import Post
 from schedule_client.utils.atproto_client import AtprotoClient
 from schedule_client.utils.data_models import AccountObject
 from schedule_client.utils.django_client import PostClient, ConfigClient
@@ -35,11 +34,13 @@ def handle_account_posts(post_client: PostClient, account: AccountObject) -> Non
             raise
 
         if scheduled_posts:
-            atproto_client = AtprotoClient(
-                account.bluesky_username, account.bluesky_password
-            )
-            if atproto_client.is_valid_login:
-                for scheduled_post in scheduled_posts:
-                    print(f"Posting: {scheduled_post.__str__}")
-                    atproto_client.post_to_account(scheduled_post)
-            del atproto_client
+            try:
+                atproto_client = AtprotoClient(
+                    account.bluesky_username, account.bluesky_password
+                )
+                if atproto_client.is_valid_login:
+                    for scheduled_post in scheduled_posts:
+                        print(f"Posting: {scheduled_post.__str__}")
+                        atproto_client.post_to_account(scheduled_post)
+            finally:
+                del atproto_client

--- a/schedule_client/utils/atproto_client.py
+++ b/schedule_client/utils/atproto_client.py
@@ -2,6 +2,7 @@ import re
 import typing as t
 
 from atproto import Client, models
+from django.utils import timezone
 
 from schedule_client.utils.django_client import PostClient
 from schedule_client.utils.data_models import PostObject, AccountObject
@@ -20,9 +21,11 @@ class AtprotoClient:
             self.client.login(self.bluesky_username, self.bluesky_password)
             self.is_valid_login = True
             print("Successfully logged into Bluesky account.")
-        except:
-            print("Error logging into Bluesky account.")
+            self.atproto_time = self.client.get_current_time()
+        except Exception as e:
+            print(f"Error logging into Bluesky account:\n{e}")
             self.is_valid_login = False
+            raise
 
     def post_to_account(self, post: PostObject) -> bool:
         """Posts to Bluesky

--- a/schedule_client/utils/django_client.py
+++ b/schedule_client/utils/django_client.py
@@ -21,7 +21,7 @@ class PostClient:
     def clear_past_scheduled_times(self) -> None:
         """Remove scheduled times for unposted elements that are scheduled in the past"""
         past_scheduled_posts = self.non_draft_unpublished_posts.filter(
-            scheduled_post_time__lt=timezone.now()-SCHEDULER_INTERVAL
+            scheduled_post_time__lt=timezone.now()-9*SCHEDULER_INTERVAL
         ).all()
 
         for past_scheduled_post in past_scheduled_posts:
@@ -90,8 +90,8 @@ class PostClient:
             bluesky_username=account.bluesky_username
         )
 
-        schedule_window_begin = timezone.now() - SCHEDULER_INTERVAL
-        schedule_window_end = timezone.now() + SCHEDULER_INTERVAL
+        schedule_window_begin = timezone.now() - 10 * SCHEDULER_INTERVAL
+        schedule_window_end = timezone.now()
 
         posts_within_window = (
             account_filtered_posts.exclude(


### PR DESCRIPTION
Shorten `SCHEDULER_INTERVAL` to 5 seconds and then collect scheduled posts for up to 50 seconds before current time. Simultaneously, do not publish posts scheduled ahead of current time, and only reset scheduled times for unpublished items if they're over 45 seconds past their scheduled time.